### PR TITLE
Fixes #13 where program exits when imagemagick binary not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The full list of default icon sizes (in pixels) is:
 
 MIT License
 
-Copyright (c) 2013-2017 Alex Ehrnschwender (http://alexehrnschwender.com/)
+Copyright (c) 2013-2021 Alex Ehrnschwender (http://alexehrnschwender.com/)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,7 +9,7 @@ var iconerator = require('../lib/iconerator'),
 
 commander
     .version(packageJson.version)
-    .usage('[options] <file ...> <output directory ...>') 
+    .usage('[options] <file ...> <output directory ...>')
     .option('--only-ios', 'Only generate iOS icons')
     .option('--only-android', 'Only generate Android icons')
     .option('--only-iphone', 'Only generate iPhone icons')
@@ -18,9 +18,9 @@ commander
     .parse(process.argv);
 
 var inputImage = path.resolve(process.cwd(), commander.args[0]);
-var outputPath = (commander.args[1] && 
-                  fs.statSync(path.resolve(process.cwd(), commander.args[1])).isDirectory()) ? 
-                    path.resolve(process.cwd(), commander.args[1]) : 
+var outputPath = (commander.args[1] &&
+                  fs.statSync(path.resolve(process.cwd(), commander.args[1])).isDirectory()) ?
+                    path.resolve(process.cwd(), commander.args[1]) :
                       process.cwd();
 
 // Establish and clean input file & output path
@@ -51,7 +51,7 @@ if(commander.onlyIos) {
 iconerator.checkDependencies(function(err){
     if(err){
         console.error(err);
-        process.exit(1);
+        //process.exit(1);
     }
     iconerator.generateIcons(inputImage, outputPath, platform, device, function(err){
         if(err){
@@ -59,6 +59,6 @@ iconerator.checkDependencies(function(err){
             process.exit(1);
         }
         console.log("Successfully generated app icon images in ", outputPath);
-    }); 
+    });
 });
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "private": false,
   "description": "Generate all app market icons from a single input image (iOS + Android + Web)",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexanderscott/iconerator.git"


### PR DESCRIPTION
Because not all linux distros use `/usr/bin/type`, do not exit the program if checkDependencies fails.